### PR TITLE
Add support for building 3.2.0 with yjit flags enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Follow the [README](https://github.com/basecamp/work#first-time-setup) in order 
 
     $ bin/build_ruby -d ubuntu:18.04 -a amd64 -i "37s~bionic" -r 2.4.1
     $ bin/build_ruby -d ubuntu:18.04:libssl -a amd64 -i "37s~bionic.libssl" -r 3.1.2
+    
+    # Ruby 3.2.0 + YJIT support
+    $ bin/build_ruby -d ubuntu:18.04:yjit -a amd64 -i "37s~bionic" -r 3.2.0
 
 ### Other options
 

--- a/build_ruby.go
+++ b/build_ruby.go
@@ -20,6 +20,7 @@ var (
 	distros = map[string]string{
 		"ubuntu:18.04":        "ubuntu:18.04",
 		"ubuntu:18.04:libssl": "ubuntu:18.04:libssl", // drop this variant once we move beyond bionic
+		"ubuntu:18.04:yjit":   "ubuntu:18.04:yjit",   // used for building 3.2.0 with yjit support
 	}
 
 	docker_client   *docker.Client
@@ -346,8 +347,10 @@ func dockerFileFromTemplate(distro, ruby_version, arch, iteration string, patche
 	switch distro {
 	case "ubuntu:18.04":
 		template_location = "data/Dockerfile-bionic.template"
-        case "ubuntu:18.04:libssl": // drop this variant once we move beyond bionic
+	case "ubuntu:18.04:libssl": // drop this variant once we move beyond bionic
 		template_location = "data/Dockerfile-bionic-libssl.template"
+	case "ubuntu:18.04:yjit": // used for building 3.2.0 with yjit support
+		template_location = "data/Dockerfile-bionic-yjit.template"
 	default:
 		template_location = "data/Dockerfile.template"
 	}
@@ -380,6 +383,8 @@ func gemfilesFromDistro(distro string) (string, string) {
 	case "ubuntu:18.04":
 		return "data/Gemfile.bionic", "data/Gemfile.bionic.lock"
 	case "ubuntu:18.04:libssl": // drop this variant once we move beyond bionic
+		return "data/Gemfile.bionic", "data/Gemfile.bionic.lock"
+	case "ubuntu:18.04:yjit": // used for building 3.2.0 with yjit support
 		return "data/Gemfile.bionic", "data/Gemfile.bionic.lock"
 	default:
 		return "data/Gemfile.template", "data/Gemfile.template.lock"

--- a/data/Dockerfile-bionic-yjit.template
+++ b/data/Dockerfile-bionic-yjit.template
@@ -1,0 +1,51 @@
+# Can't use {{.Distro}} since it's ubuntu:18.04:yjit
+FROM ubuntu:18.04
+RUN apt-get update
+RUN apt-get install -y build-essential \
+    libc6-dev libffi-dev libgdbm-dev libncurses5-dev \
+    libreadline-dev libssl1.0-dev libyaml-dev zlib1g-dev rustc \
+    curl ruby ruby-dev
+RUN ["/usr/bin/gem", "install", "bundler", "-v", "1.17.3", "--no-rdoc", "--no-ri"]
+ADD Gemfile /
+ADD Gemfile.lock /
+RUN ["bundle", "install"]
+
+RUN curl {{.DownloadUrl}}|tar oxzC /tmp
+{{range .Patches}}ADD {{.}} /
+{{end}}
+WORKDIR /tmp/ruby-{{.RubyVersion}}
+RUN for i in `/bin/ls /*.patch`; do patch -p0 < $i; done
+RUN CFLAGS='-march=x86-64 -O3 -fno-fast-math -g3 -ggdb -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wunused-variable -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -std=iso9899:1999  -fPIC' ./configure \
+  --prefix=/opt/ruby{{.RubyVersion}} \
+  --enable-shared \
+  --disable-install-doc \
+  --enable-load-relative \
+  --enable-yjit
+# Seems to only affect some 1.9 series Rubies, but the combined make step:
+#
+#     RUN make -j8 install DESTDIR=/tmp/fpm
+#
+# that ran the make then make install, was broken. Splitting it up into
+# two separate commands works fine:
+RUN make -j{{.NumCPU}}
+RUN make install DESTDIR=/tmp/fpm
+
+WORKDIR /
+RUN fpm \
+    -s dir \
+    -t deb \
+    -n ruby-{{.RubyVersion}} \
+    -a {{.Arch}} \
+    -v {{.RubyVersion}} \
+    {{.Iteration}}
+    -d libc6-dev \
+    -d libffi-dev \
+    -d libgdbm-dev \
+    -d libncurses5-dev \
+    -d libreadline-dev \
+    -d libssl1.0-dev \
+    -d libyaml-dev \
+    -d zlib1g-dev \
+    -C /tmp/fpm \
+    -p /{{.FileName}} \
+    opt


### PR DESCRIPTION
Ruby needs --enable-yjit and rustc available to build it with YJIT support.